### PR TITLE
Remove windows-specific paths 

### DIFF
--- a/mazerunner/Display.py
+++ b/mazerunner/Display.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 from PyQt5.Qt import QIntValidator, QEasingCurve
 from PyQt5.QtCore import QRect, QTimer, pyqtSlot, QPropertyAnimation
@@ -25,7 +25,8 @@ class App(QMainWindow):
         self.height = Config.WINDOW_HEIGHT
         self.setWindowTitle(self.title)
         self.setGeometry(self.left, self.top, self.width, self.height)
-        self.setWindowIcon(QIcon(resource_path('resources\\icon-512.png')))
+        icon_path = Path('resources/icon-512.png')
+        self.setWindowIcon(QIcon(str(resource_path(icon_path).resolve())))
 
         # Set up tabs
         self.tab_widget = TabWidget(self)
@@ -241,10 +242,10 @@ def except_hook(cls, exception, traceback):
 def resource_path(relative_path):
     """ Returns the absolute path to a resource, works for dev and PyInstaller. """
     try:
-        base_path = sys._MEIPASS
+        base_path = Path(sys._MEIPASS)
     except AttributeError:
-        base_path = os.path.abspath('..')
-    return os.path.join(base_path, relative_path)
+        base_path = Path('..').resolve()
+    return base_path / relative_path
 
 
 if __name__ == '__main__':

--- a/mazerunner/MazeGenerator.py
+++ b/mazerunner/MazeGenerator.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from random import randint
 from time import time
 
@@ -84,11 +84,12 @@ class MazeGenerator:
         containing a 4 bit number. The lines are the cells in order where a 1 indicates a wall (ordered top right
         bottom left). In total the file will have columns x rows + 1 lines
         """
-        path = os.path.join('.', 'mazes')
-        if not os.path.exists(path):
-            os.makedirs(path)
-        filename = ".\\mazes\\maze-{}x{}-{}.txt".format(self.display.columns, self.display.rows, time())
-        with open(filename, 'w') as file:
+        path = Path('./mazes')
+        if not path.exists():
+            path.mkdir(parents=True)
+        filename = "maze-{}x{}-{}.txt".format(self.display.columns, self.display.rows, time())
+        file = path / filename
+        with open(file, 'w') as file:
             # Write the maze dimensions
             file.write("{} {}".format(self.display.columns, self.display.rows))
             for cell in self.cells:

--- a/mazerunner/MazeRunner.py
+++ b/mazerunner/MazeRunner.py
@@ -75,7 +75,8 @@ class MazeRunner:
         """
         # Allow user to select filename
         dialog = QFileDialog()
-        filename = dialog.getOpenFileName(dialog, "Load maze", '.\\mazes\\', '*.txt')[0]
+        path = Path('./mazes')
+        filename = dialog.getOpenFileName(dialog, "Load maze", str(path.resolve()), '*.txt')[0]
         if not filename:
             # No filename chosen
             return False


### PR DESCRIPTION
This maintains the expected save and load procedure on linux machines. 
Icon support in pyinstaller still works.